### PR TITLE
Generating API Docs for both Drone and Server APIs

### DIFF
--- a/api_docs/doc_gen.py
+++ b/api_docs/doc_gen.py
@@ -1,0 +1,59 @@
+"""API Doc templates generator."""
+
+
+def hydra_doc(API, title, desc, entrypoint):
+    """Template for a new API Doc."""
+    return {
+        "@context": "http://hydrus.com/contexts/"+API+".jsonld",
+        "@id": "http://hydrus.com/"+API+"/vocab",
+        "@type": "ApiDocumentation",
+        "title": title,
+        "description": desc,
+        "entrypoint": entrypoint,
+        "supportedClass": [
+        ],
+        "possibleStatus": [
+        ]
+    }
+
+
+def hydra_class(class_, title, desc, entrypoint):
+    """Template for a new class."""
+    return {
+        "@context": "http://hydrus.com/context/"+class_+".jsonld",
+        "@id": "http://hydrus.com/"+entrypoint+"/vocab/"+class_,
+        "@type": "Class",
+        "title": title,
+        "description": desc,
+        "supportedProperty": [
+
+        ],
+        "supportedOperation": [
+
+        ]
+    }
+
+
+def hydra_prop(prop, title, read, write, required):
+    """Template for a new property."""
+    return {
+      "@type": "SupportedProperty",
+      "title": title,
+      "property": prop,
+      "required": required,
+      "readable": read,
+      "writeable": write
+    }
+
+
+def hydra_op(id_, title, method, expects, returns, status):
+    """Template for a new Operation."""
+    return {
+            "@type": "Operation",
+            "@id": id_,
+            "title": title,
+            "method": method,
+            "expects": expects,
+            "returns": returns,
+            "possibleStatus": status
+        }

--- a/api_docs/doc_gen.py
+++ b/api_docs/doc_gen.py
@@ -1,59 +1,123 @@
 """API Doc templates generator."""
 
 
-def hydra_doc(API, title, desc, entrypoint):
+class HydraDoc():
     """Template for a new API Doc."""
-    return {
-        "@context": "http://hydrus.com/contexts/"+API+".jsonld",
-        "@id": "http://hydrus.com/"+API+"/vocab",
-        "@type": "ApiDocumentation",
-        "title": title,
-        "description": desc,
-        "entrypoint": entrypoint,
-        "supportedClass": [
-        ],
-        "possibleStatus": [
-        ]
-    }
 
-
-def hydra_class(class_, title, desc, entrypoint):
-    """Template for a new class."""
-    return {
-        "@context": "http://hydrus.com/context/"+class_+".jsonld",
-        "@id": "http://hydrus.com/"+entrypoint+"/vocab/"+class_,
-        "@type": "Class",
-        "title": title,
-        "description": desc,
-        "supportedProperty": [
-
-        ],
-        "supportedOperation": [
-
-        ]
-    }
-
-
-def hydra_prop(prop, title, read, write, required):
-    """Template for a new property."""
-    return {
-      "@type": "SupportedProperty",
-      "title": title,
-      "property": prop,
-      "required": required,
-      "readable": read,
-      "writeable": write
-    }
-
-
-def hydra_op(id_, title, method, expects, returns, status):
-    """Template for a new Operation."""
-    return {
-            "@type": "Operation",
-            "@id": id_,
+    def __init__(self, API, title, desc, entrypoint):
+        """Initialize the Hydra_APIDoc."""
+        self.doc = {
+            "@context": "http://hydrus.com/contexts/"+API+".jsonld",
+            "@id": "http://hydrus.com/"+API+"/vocab",
+            "@type": "ApiDocumentation",
             "title": title,
-            "method": method,
-            "expects": expects,
-            "returns": returns,
-            "possibleStatus": status
+            "description": desc,
+            "entrypoint": entrypoint,
+            "supportedClass": [
+            ],
+            "possibleStatus": [
+            ]
         }
+
+    def add_supported_class(self, class_):
+        """Add a new supportedClass."""
+        self.doc["supportedClass"].append(class_)
+
+    def add_possible_status(self, status):
+        """Add a new possibleStatus."""
+        self.doc["possibleStatus"].append(status)
+
+    def to_json(self):
+        """Return the Hydra JSON for the API Doc."""
+        import json
+        return json.dumps(self.doc, indent=4, sort_keys=True)
+
+    def get(self):
+        """Get the Hydra API Doc as a python dict."""
+        return self.doc
+
+
+class HydraClass():
+    """Template for a new class."""
+
+    def __init__(self, class_, title, desc, entrypoint):
+        """Initialize the Hydra_Class."""
+        self.class_ = {
+            "@context": "http://hydrus.com/context/"+class_+".jsonld",
+            "@id": "http://hydrus.com/"+entrypoint+"/vocab/"+class_,
+            "@type": "Class",
+            "title": title,
+            "description": desc,
+            "supportedProperty": [
+
+            ],
+            "supportedOperation": [
+
+            ]
+        }
+
+    def add_supported_prop(self, prop):
+        """Add a new supportedProperty."""
+        self.class_["supportedProperty"].append(prop)
+
+    def add_supported_op(self, op):
+        """Add a new supportedOperation."""
+        self.class_["supportedOperation"].append(op)
+
+    def to_json(self):
+        """Return the Hydra JSON for the class."""
+        import json
+        return json.dumps(self.class_, indent=4, sort_keys=True)
+
+    def get(self):
+        """Get the Hydra class as a python dict."""
+        return self.class_
+
+
+class HydraProp():
+    """Template for a new property."""
+
+    def __init__(self, prop, title, read, write, required):
+        """Initialize the Hydra_Prop."""
+        self.prop = {
+          "@type": "SupportedProperty",
+          "title": title,
+          "property": prop,
+          "required": required,
+          "readable": read,
+          "writeable": write
+        }
+
+    def to_json(self):
+        """Return the Hydra JSON for the prop."""
+        import json
+        return json.dumps(self.prop, indent=4, sort_keys=True)
+
+    def get(self):
+        """Get the Hydra prop as a python dict."""
+        return self.prop
+
+
+class HydraOp():
+    """Template for a new Operation."""
+
+    def __init__(self, id_, title, method, expects, returns, status):
+        """Initialize the Hydra_Prop."""
+        self.op = {
+                "@type": "Operation",
+                "@id": id_,
+                "title": title,
+                "method": method,
+                "expects": expects,
+                "returns": returns,
+                "possibleStatus": status
+            }
+
+    def to_json(self):
+        """Return the Hydra JSON for the op."""
+        import json
+        return json.dumps(self.op, indent=4, sort_keys=True)
+
+    def get(self):
+        """Get the Hydra op as a python dict."""
+        return self.op

--- a/api_docs/doc_writer.py
+++ b/api_docs/doc_writer.py
@@ -4,11 +4,11 @@
 class HydraDoc():
     """Template for a new API Doc."""
 
-    def __init__(self, API, title, desc, entrypoint):
+    def __init__(self, API, title, desc, entrypoint, base_url):
         """Initialize the Hydra_APIDoc."""
         self.doc = {
-            "@context": "http://hydrus.com/contexts/"+API+".jsonld",
-            "@id": "http://hydrus.com/"+API+"/vocab",
+            "@context": base_url + "contexts/" + API + ".jsonld",
+            "@id": base_url + API + "/vocab",
             "@type": "ApiDocumentation",
             "title": title,
             "description": desc,
@@ -40,12 +40,13 @@ class HydraDoc():
 class HydraClass():
     """Template for a new class."""
 
-    def __init__(self, class_, title, desc, entrypoint):
+    def __init__(self, class_, title, desc, entrypoint, base_url, sub_classof=None):
         """Initialize the Hydra_Class."""
         self.class_ = {
-            "@context": "http://hydrus.com/context/"+class_+".jsonld",
-            "@id": "http://hydrus.com/"+entrypoint+"/vocab/"+class_,
+            "@context": base_url + "context/" + class_ + ".jsonld",
+            "@id": base_url + entrypoint + "/vocab#" + class_,
             "@type": "Class",
+            "subClassOf": "null",
             "title": title,
             "description": desc,
             "supportedProperty": [
@@ -55,6 +56,8 @@ class HydraClass():
 
             ]
         }
+        if sub_classof is not None:
+            self.class_["subClassOf"] = sub_classof
 
     def add_supported_prop(self, prop):
         """Add a new supportedProperty."""

--- a/api_docs/doc_writer.py
+++ b/api_docs/doc_writer.py
@@ -124,3 +124,12 @@ class HydraOp():
     def get(self):
         """Get the Hydra op as a python dict."""
         return self.op
+
+
+def gen_parsed_classes(api_doc):
+    """Extracts the parsed classes from the Hydra  APIDoc."""
+    parsed_classes = list()
+    for class_ in api_doc["supportedClass"]:
+        if class_["@type"] != "Class":
+            parsed_classes.append(class_)
+    return parsed_classes

--- a/api_docs/drone_doc.py
+++ b/api_docs/drone_doc.py
@@ -9,44 +9,76 @@ drone_doc = {
     "possibleStatus": [],
     "supportedClass": [
         {
+            "@context": "http://hydrus.com/context/Status.jsonld",
+            "@id": "http://hydrus.com/droneapi/vocab#Status",
+            "@type": "Class",
+            "description": "Class for drone status objects",
+            "subClassOf": "null",
+            "supportedOperation": [],
+            "supportedProperty": [
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://auto.schema.org/speed",
+                    "readable": "true",
+                    "required": "false",
+                    "title": "Speed",
+                    "writeable": "false"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://schema.org/geo",
+                    "readable": "true",
+                    "required": "false",
+                    "title": "Position",
+                    "writeable": "false"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://schema.org/fuelCapacity",
+                    "readable": "true",
+                    "required": "false",
+                    "title": "Battery",
+                    "writeable": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://schema.org/device",
+                    "readable": "true",
+                    "required": "false",
+                    "title": "Sensor",
+                    "writeable": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://schema.org/model",
+                    "readable": "true",
+                    "required": "false",
+                    "title": "Model",
+                    "writeable": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "https://schema.org/status",
+                    "readable": "true",
+                    "required": "false",
+                    "title": "SensorStatus",
+                    "writeable": "false"
+                }
+            ],
+            "title": "Status"
+        },
+        {
             "@context": "http://hydrus.com/context/Drone.jsonld",
-            "@id": "http://hydrus.com/droneapi/vocab/Drone",
+            "@id": "http://hydrus.com/droneapi/vocab#Drone",
             "@type": "Class",
             "description": "Class for a drone",
+            "subClassOf": "null",
             "supportedOperation": [
                 {
-                    "@id": ":change_speed",
+                    "@id": "/droneapi/issue_order",
                     "@type": "Operation",
-                    "expects": "http://auto.schema.org/speed",
-                    "method": "PUT",
-                    "possibleStatus": [
-                        {
-                            "code": 200,
-                            "description": "Speed Changed"
-                        }
-                    ],
-                    "returns": "null",
-                    "title": "ChangeSpeed"
-                },
-                {
-                    "@id": ":change_position",
-                    "@type": "Operation",
-                    "expects": "http://schema.org/geo",
-                    "method": "PUT",
-                    "possibleStatus": [
-                        {
-                            "code": 200,
-                            "description": "Position Changed"
-                        }
-                    ],
-                    "returns": "null",
-                    "title": "ChangePosition"
-                },
-                {
-                    "@id": ":change_status",
-                    "@type": "Operation",
-                    "expects": "http://schema.org/status",
-                    "method": "PUT",
+                    "expects": "vocab: Status",
+                    "method": "POST",
                     "possibleStatus": [
                         {
                             "code": 200,
@@ -57,152 +89,28 @@ drone_doc = {
                     "title": "ChangeStatus"
                 },
                 {
-                    "@id": ":get_speed",
+                    "@id": "/droneapi/get_status",
                     "@type": "Operation",
                     "expects": "null",
                     "method": "GET",
                     "possibleStatus": [
                         {
                             "code": 200,
-                            "description": "Speed returned"
+                            "description": "Status Returned"
                         }
                     ],
-                    "returns": "http://auto.schema.org/speed",
-                    "title": "GetSpeed"
-                },
-                {
-                    "@id": ":get_position",
-                    "@type": "Operation",
-                    "expects": "null",
-                    "method": "GET",
-                    "possibleStatus": [
-                        {
-                            "code": 200,
-                            "description": "Position returned"
-                        }
-                    ],
-                    "returns": "http://schema.org/geo",
-                    "title": "GetPosition"
-                },
-                {
-                    "@id": ":get_battery_status",
-                    "@type": "Operation",
-                    "expects": "null",
-                    "method": "GET",
-                    "possibleStatus": [
-                        {
-                            "code": 200,
-                            "description": "Battery status returned"
-                        }
-                    ],
-                    "returns": "http://schema.org/fuelCapacity",
-                    "title": "GetBatteryStatus"
-                },
-                {
-                    "@id": ":get_model",
-                    "@type": "Operation",
-                    "expects": "null",
-                    "method": "GET",
-                    "possibleStatus": [
-                        {
-                            "code": 200,
-                            "description": "Model returned"
-                        }
-                    ],
-                    "returns": "http://schema.org/model",
-                    "title": "GetModel"
-                },
-                {
-                    "@id": ":get_status",
-                    "@type": "Operation",
-                    "expects": "null",
-                    "method": "GET",
-                    "possibleStatus": [
-                        {
-                            "code": 200,
-                            "description": "Status returned"
-                        }
-                    ],
-                    "returns": "http://schema.org/status",
+                    "returns": "vocab: Status",
                     "title": "GetStatus"
-                },
-                {
-                    "@id": ":get_temperature",
-                    "@type": "Operation",
-                    "expects": "null",
-                    "method": "GET",
-                    "possibleStatus": [
-                        {
-                            "code": 200,
-                            "description": "Temperature returned"
-                        }
-                    ],
-                    "returns": "http://schema.org/Float",
-                    "title": "GetTemperature"
-                },
-                {
-                    "@id": ":recharge",
-                    "@type": "Operation",
-                    "expects": "http://schema.org/Action",
-                    "method": "POST",
-                    "possibleStatus": [
-                        {
-                            "code": 200,
-                            "description": "Successfully charged"
-                        }
-                    ],
-                    "returns": "http://schema.org/fuelCapacity",
-                    "title": "GetTemperature"
                 }
             ],
             "supportedProperty": [
                 {
                     "@type": "SupportedProperty",
-                    "property": "http://auto.schema.org/speed",
+                    "property": "vocab:Status",
                     "readable": "true",
-                    "required": "true",
-                    "title": "Speed",
-                    "writeable": "true"
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "http://schema.org/geo",
-                    "readable": "true",
-                    "required": "true",
-                    "title": "Position",
-                    "writeable": "true"
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "http://schema.org/fuelCapacity",
-                    "readable": "true",
-                    "required": "true",
-                    "title": "Battery",
-                    "writeable": "true"
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "http://schema.org/device",
-                    "readable": "true",
-                    "required": "true",
-                    "title": "Sensor",
+                    "required": "false",
+                    "title": "DroneStatus",
                     "writeable": "false"
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "http://schema.org/model",
-                    "readable": "true",
-                    "required": "true",
-                    "title": "Model",
-                    "writeable": "false"
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "https://schema.org/status",
-                    "readable": "true",
-                    "required": "true",
-                    "title": "Status",
-                    "writeable": "true"
                 }
             ],
             "title": "Drone"

--- a/api_docs/drone_doc.py
+++ b/api_docs/drone_doc.py
@@ -1,0 +1,212 @@
+"""Generated API Documentation for Drone API using drone_doc_gen.py."""
+
+drone_doc = {
+    "@context": "http://hydrus.com/contexts/droneapi.jsonld",
+    "@id": "http://hydrus.com/droneapi/vocab",
+    "@type": "ApiDocumentation",
+    "description": "API Documentation for the drone side system",
+    "entrypoint": "/droneapi/",
+    "possibleStatus": [],
+    "supportedClass": [
+        {
+            "@context": "http://hydrus.com/context/Drone.jsonld",
+            "@id": "http://hydrus.com/droneapi/vocab/Drone",
+            "@type": "Class",
+            "description": "Class for a drone",
+            "supportedOperation": [
+                {
+                    "@id": ":change_speed",
+                    "@type": "Operation",
+                    "expects": "http://auto.schema.org/speed",
+                    "method": "PUT",
+                    "possibleStatus": [
+                        {
+                            "code": 200,
+                            "description": "Speed Changed"
+                        }
+                    ],
+                    "returns": "null",
+                    "title": "ChangeSpeed"
+                },
+                {
+                    "@id": ":change_position",
+                    "@type": "Operation",
+                    "expects": "http://schema.org/geo",
+                    "method": "PUT",
+                    "possibleStatus": [
+                        {
+                            "code": 200,
+                            "description": "Position Changed"
+                        }
+                    ],
+                    "returns": "null",
+                    "title": "ChangePosition"
+                },
+                {
+                    "@id": ":change_status",
+                    "@type": "Operation",
+                    "expects": "http://schema.org/status",
+                    "method": "PUT",
+                    "possibleStatus": [
+                        {
+                            "code": 200,
+                            "description": "Status Changed"
+                        }
+                    ],
+                    "returns": "null",
+                    "title": "ChangeStatus"
+                },
+                {
+                    "@id": ":get_speed",
+                    "@type": "Operation",
+                    "expects": "null",
+                    "method": "GET",
+                    "possibleStatus": [
+                        {
+                            "code": 200,
+                            "description": "Speed returned"
+                        }
+                    ],
+                    "returns": "http://auto.schema.org/speed",
+                    "title": "GetSpeed"
+                },
+                {
+                    "@id": ":get_position",
+                    "@type": "Operation",
+                    "expects": "null",
+                    "method": "GET",
+                    "possibleStatus": [
+                        {
+                            "code": 200,
+                            "description": "Position returned"
+                        }
+                    ],
+                    "returns": "http://schema.org/geo",
+                    "title": "GetPosition"
+                },
+                {
+                    "@id": ":get_battery_status",
+                    "@type": "Operation",
+                    "expects": "null",
+                    "method": "GET",
+                    "possibleStatus": [
+                        {
+                            "code": 200,
+                            "description": "Battery status returned"
+                        }
+                    ],
+                    "returns": "http://schema.org/fuelCapacity",
+                    "title": "GetBatteryStatus"
+                },
+                {
+                    "@id": ":get_model",
+                    "@type": "Operation",
+                    "expects": "null",
+                    "method": "GET",
+                    "possibleStatus": [
+                        {
+                            "code": 200,
+                            "description": "Model returned"
+                        }
+                    ],
+                    "returns": "http://schema.org/model",
+                    "title": "GetModel"
+                },
+                {
+                    "@id": ":get_status",
+                    "@type": "Operation",
+                    "expects": "null",
+                    "method": "GET",
+                    "possibleStatus": [
+                        {
+                            "code": 200,
+                            "description": "Status returned"
+                        }
+                    ],
+                    "returns": "http://schema.org/status",
+                    "title": "GetStatus"
+                },
+                {
+                    "@id": ":get_temperature",
+                    "@type": "Operation",
+                    "expects": "null",
+                    "method": "GET",
+                    "possibleStatus": [
+                        {
+                            "code": 200,
+                            "description": "Temperature returned"
+                        }
+                    ],
+                    "returns": "http://schema.org/Float",
+                    "title": "GetTemperature"
+                },
+                {
+                    "@id": ":recharge",
+                    "@type": "Operation",
+                    "expects": "http://schema.org/Action",
+                    "method": "POST",
+                    "possibleStatus": [
+                        {
+                            "code": 200,
+                            "description": "Successfully charged"
+                        }
+                    ],
+                    "returns": "http://schema.org/fuelCapacity",
+                    "title": "GetTemperature"
+                }
+            ],
+            "supportedProperty": [
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://auto.schema.org/speed",
+                    "readable": "true",
+                    "required": "true",
+                    "title": "Speed",
+                    "writeable": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://schema.org/geo",
+                    "readable": "true",
+                    "required": "true",
+                    "title": "Position",
+                    "writeable": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://schema.org/fuelCapacity",
+                    "readable": "true",
+                    "required": "true",
+                    "title": "Battery",
+                    "writeable": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://schema.org/device",
+                    "readable": "true",
+                    "required": "true",
+                    "title": "Sensor",
+                    "writeable": "false"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://schema.org/model",
+                    "readable": "true",
+                    "required": "true",
+                    "title": "Model",
+                    "writeable": "false"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "https://schema.org/status",
+                    "readable": "true",
+                    "required": "true",
+                    "title": "Status",
+                    "writeable": "true"
+                }
+            ],
+            "title": "Drone"
+        }
+    ],
+    "title": "API Doc for the drone side API"
+}

--- a/api_docs/drone_doc_gen.py
+++ b/api_docs/drone_doc_gen.py
@@ -1,0 +1,102 @@
+"""API Doc generator for the drone side API."""
+
+import json
+from doc_gen import hydra_doc, hydra_class, hydra_prop, hydra_op
+
+
+def drone_doc(API):
+    """Generate API Doc for drone."""
+    # Main API Doc
+    api_doc = hydra_doc(API,
+                        "API Doc for the drone side API",
+                        "API Documentation for the drone side system",
+                        "/"+API+"/")
+
+    # Drone Class
+    drone = hydra_class("Drone", "Drone", "Class for a drone", API)
+
+    # Properties
+    drone["supportedProperty"].append(hydra_prop("http://auto.schema.org/speed", "Speed", "true", "true", "true"))
+    drone["supportedProperty"].append(hydra_prop("http://schema.org/geo", "Position", "true", "true", "true"))
+    drone["supportedProperty"].append(hydra_prop("http://schema.org/fuelCapacity", "Battery", "true", "true", "true"))
+    drone["supportedProperty"].append(hydra_prop("http://schema.org/device", "Sensor", "true", "false", "true"))
+    drone["supportedProperty"].append(hydra_prop("http://schema.org/model", "Model", "true", "false", "true"))
+    drone["supportedProperty"].append(hydra_prop("https://schema.org/status", "Status", "true", "true", "true"))
+
+    # Operations
+    drone["supportedOperation"].append(hydra_op("/"+API+"/change_speed",
+                                                "ChangeSpeed",
+                                                "PUT",
+                                                "http://auto.schema.org/speed",
+                                                "null",
+                                                [{"code": 200, "description": "Speed Changed"}]))
+
+    drone["supportedOperation"].append(hydra_op("/"+API+"/change_position",
+                                                "ChangePosition",
+                                                "PUT",
+                                                "http://schema.org/geo",
+                                                "null",
+                                                [{"code": 200, "description": "Position Changed"}]))
+
+    drone["supportedOperation"].append(hydra_op("/"+API+"/change_status",
+                                                "ChangeStatus",
+                                                "PUT",
+                                                "http://schema.org/status",
+                                                "null",
+                                                [{"code": 200, "description": "Status Changed"}]))
+
+    drone["supportedOperation"].append(hydra_op("/"+API+"/get_speed",
+                                                "GetSpeed",
+                                                "GET",
+                                                "null",
+                                                "http://auto.schema.org/speed",
+                                                [{"code": 200, "description": "Speed returned"}]))
+
+    drone["supportedOperation"].append(hydra_op("/"+API+"/get_position",
+                                                "GetPosition",
+                                                "GET",
+                                                "null",
+                                                "http://schema.org/geo",
+                                                [{"code": 200, "description": "Position returned"}]))
+
+    drone["supportedOperation"].append(hydra_op("/"+API+"/get_battery_status",
+                                                "GetBatteryStatus",
+                                                "GET",
+                                                "null",
+                                                "http://schema.org/fuelCapacity",
+                                                [{"code": 200, "description": "Battery status returned"}]))
+
+    drone["supportedOperation"].append(hydra_op("/"+API+"/get_model",
+                                                "GetModel",
+                                                "GET",
+                                                "null",
+                                                "http://schema.org/model",
+                                                [{"code": 200, "description": "Model returned"}]))
+
+    drone["supportedOperation"].append(hydra_op("/"+API+"/get_status",
+                                                "GetStatus",
+                                                "GET",
+                                                "null",
+                                                "http://schema.org/status",
+                                                [{"code": 200, "description": "Status returned"}]))
+
+    drone["supportedOperation"].append(hydra_op("/"+API+"/get_temperature",
+                                                "GetTemperature",
+                                                "GET",
+                                                "null",
+                                                "http://schema.org/Float",
+                                                [{"code": 200, "description": "Temperature returned"}]))
+
+    drone["supportedOperation"].append(hydra_op("/"+API+"/recharge",
+                                                "GetTemperature",
+                                                "POST",
+                                                "http://schema.org/Action",
+                                                "http://schema.org/fuelCapacity",
+                                                [{"code": 200, "description": "Successfully charged"}]))
+    api_doc["supportedClass"].append(drone)
+
+    return api_doc
+
+
+if __name__ == "__main__":
+    print(json.dumps(drone_doc("droneapi"), indent=4, sort_keys=True))

--- a/api_docs/drone_doc_gen.py
+++ b/api_docs/drone_doc_gen.py
@@ -1,102 +1,54 @@
 """API Doc generator for the drone side API."""
 
-import json
-from doc_gen import HydraDoc, HydraClass, HydraProp, HydraOp
+from doc_writer import HydraDoc, HydraClass, HydraProp, HydraOp
 
 
-def drone_doc(API):
+def drone_doc(API, BASE_URL):
     """Generate API Doc for drone."""
     # Main API Doc
     api_doc = HydraDoc(API,
                        "API Doc for the drone side API",
                        "API Documentation for the drone side system",
-                       "/"+API+"/")
+                       "/"+API+"/",
+                       BASE_URL)
 
-    # Drone Class
-    drone = HydraClass("Drone", "Drone", "Class for a drone", API)
+    # Status Class
+    status = HydraClass("Status", "Status", "Class for drone status objects", API, BASE_URL)
 
     # Properties
-    drone.add_supported_prop(HydraProp("http://auto.schema.org/speed", "Speed", "true", "true", "true").get())
-    drone.add_supported_prop(HydraProp("http://schema.org/geo", "Position", "true", "true", "true").get())
-    drone.add_supported_prop(HydraProp("http://schema.org/fuelCapacity", "Battery", "true", "true", "true").get())
-    drone.add_supported_prop(HydraProp("http://schema.org/device", "Sensor", "true", "false", "true").get())
-    drone.add_supported_prop(HydraProp("http://schema.org/model", "Model", "true", "false", "true").get())
-    drone.add_supported_prop(HydraProp("https://schema.org/status", "Status", "true", "true", "true").get())
+    status.add_supported_prop(HydraProp("http://auto.schema.org/speed", "Speed", "true", "false", "false").get())
+    status.add_supported_prop(HydraProp("http://schema.org/geo", "Position", "true", "false", "false").get())
+    status.add_supported_prop(HydraProp("http://schema.org/fuelCapacity", "Battery", "true", "true", "false").get())
+    status.add_supported_prop(HydraProp("http://schema.org/device", "Sensor", "true", "true", "false").get())
+    status.add_supported_prop(HydraProp("http://schema.org/model", "Model", "true", "true", "false").get())
+    status.add_supported_prop(HydraProp("https://schema.org/status", "SensorStatus", "true", "false", "false").get())
+
+    # Drone Class
+    drone = HydraClass("Drone", "Drone", "Class for a drone", API, BASE_URL)
+
+    # Properties
+    drone.add_supported_prop(HydraProp("vocab:Status", "DroneStatus", "true", "false", "false").get())
 
     # Operations
-    drone.add_supported_op(HydraOp("/"+API+"/change_speed",
-                                   "ChangeSpeed",
-                                   "PUT",
-                                   "http://auto.schema.org/speed",
-                                   "null",
-                                   [{"code": 200, "description": "Speed Changed"}]).get())
-
-    drone.add_supported_op(HydraOp("/"+API+"/change_position",
-                                   "ChangePosition",
-                                   "PUT",
-                                   "http://schema.org/geo",
-                                   "null",
-                                   [{"code": 200, "description": "Position Changed"}]).get())
-
-    drone.add_supported_op(HydraOp("/"+API+"/change_status",
+    drone.add_supported_op(HydraOp("/"+API+"/issue_order",
                                    "ChangeStatus",
-                                   "PUT",
-                                   "http://schema.org/status",
+                                   "POST",
+                                   "vocab: Status",
                                    "null",
                                    [{"code": 200, "description": "Status Changed"}]).get())
-
-    drone.add_supported_op(HydraOp("/"+API+"/get_speed",
-                                   "GetSpeed",
-                                   "GET",
-                                   "null",
-                                   "http://auto.schema.org/speed",
-                                   [{"code": 200, "description": "Speed returned"}]).get())
-
-    drone.add_supported_op(HydraOp("/"+API+"/get_position",
-                                   "GetPosition",
-                                   "GET",
-                                   "null",
-                                   "http://schema.org/geo",
-                                   [{"code": 200, "description": "Position returned"}]).get())
-
-    drone.add_supported_op(HydraOp("/"+API+"/get_battery_status",
-                                   "GetBatteryStatus",
-                                   "GET",
-                                   "null",
-                                   "http://schema.org/fuelCapacity",
-                                   [{"code": 200, "description": "Battery status returned"}]).get())
-
-    drone.add_supported_op(HydraOp("/"+API+"/get_model",
-                                   "GetModel",
-                                   "GET",
-                                   "null",
-                                   "http://schema.org/model",
-                                   [{"code": 200, "description": "Model returned"}]).get())
 
     drone.add_supported_op(HydraOp("/"+API+"/get_status",
                                    "GetStatus",
                                    "GET",
                                    "null",
-                                   "http://schema.org/status",
-                                   [{"code": 200, "description": "Status returned"}]).get())
+                                   "vocab: Status",
+                                   [{"code": 200, "description": "Status Returned"}]).get())
 
-    drone.add_supported_op(HydraOp("/"+API+"/get_temperature",
-                                   "GetTemperature",
-                                   "GET",
-                                   "null",
-                                   "http://schema.org/Float",
-                                   [{"code": 200, "description": "Temperature returned"}]).get())
-
-    drone.add_supported_op(HydraOp("/"+API+"/recharge",
-                                   "GetTemperature",
-                                   "POST",
-                                   "http://schema.org/Action",
-                                   "http://schema.org/fuelCapacity",
-                                   [{"code": 200, "description": "Successfully charged"}]).get())
+    api_doc.add_supported_class(status.get())
     api_doc.add_supported_class(drone.get())
 
     return api_doc
 
 
 if __name__ == "__main__":
-    print(drone_doc("droneapi").to_json())
+    print(drone_doc("droneapi", "http://hydrus.com/").to_json())

--- a/api_docs/drone_doc_gen.py
+++ b/api_docs/drone_doc_gen.py
@@ -1,102 +1,102 @@
 """API Doc generator for the drone side API."""
 
 import json
-from doc_gen import hydra_doc, hydra_class, hydra_prop, hydra_op
+from doc_gen import HydraDoc, HydraClass, HydraProp, HydraOp
 
 
 def drone_doc(API):
     """Generate API Doc for drone."""
     # Main API Doc
-    api_doc = hydra_doc(API,
-                        "API Doc for the drone side API",
-                        "API Documentation for the drone side system",
-                        "/"+API+"/")
+    api_doc = HydraDoc(API,
+                       "API Doc for the drone side API",
+                       "API Documentation for the drone side system",
+                       "/"+API+"/")
 
     # Drone Class
-    drone = hydra_class("Drone", "Drone", "Class for a drone", API)
+    drone = HydraClass("Drone", "Drone", "Class for a drone", API)
 
     # Properties
-    drone["supportedProperty"].append(hydra_prop("http://auto.schema.org/speed", "Speed", "true", "true", "true"))
-    drone["supportedProperty"].append(hydra_prop("http://schema.org/geo", "Position", "true", "true", "true"))
-    drone["supportedProperty"].append(hydra_prop("http://schema.org/fuelCapacity", "Battery", "true", "true", "true"))
-    drone["supportedProperty"].append(hydra_prop("http://schema.org/device", "Sensor", "true", "false", "true"))
-    drone["supportedProperty"].append(hydra_prop("http://schema.org/model", "Model", "true", "false", "true"))
-    drone["supportedProperty"].append(hydra_prop("https://schema.org/status", "Status", "true", "true", "true"))
+    drone.add_supported_prop(HydraProp("http://auto.schema.org/speed", "Speed", "true", "true", "true").get())
+    drone.add_supported_prop(HydraProp("http://schema.org/geo", "Position", "true", "true", "true").get())
+    drone.add_supported_prop(HydraProp("http://schema.org/fuelCapacity", "Battery", "true", "true", "true").get())
+    drone.add_supported_prop(HydraProp("http://schema.org/device", "Sensor", "true", "false", "true").get())
+    drone.add_supported_prop(HydraProp("http://schema.org/model", "Model", "true", "false", "true").get())
+    drone.add_supported_prop(HydraProp("https://schema.org/status", "Status", "true", "true", "true").get())
 
     # Operations
-    drone["supportedOperation"].append(hydra_op("/"+API+"/change_speed",
-                                                "ChangeSpeed",
-                                                "PUT",
-                                                "http://auto.schema.org/speed",
-                                                "null",
-                                                [{"code": 200, "description": "Speed Changed"}]))
+    drone.add_supported_op(HydraOp("/"+API+"/change_speed",
+                                   "ChangeSpeed",
+                                   "PUT",
+                                   "http://auto.schema.org/speed",
+                                   "null",
+                                   [{"code": 200, "description": "Speed Changed"}]).get())
 
-    drone["supportedOperation"].append(hydra_op("/"+API+"/change_position",
-                                                "ChangePosition",
-                                                "PUT",
-                                                "http://schema.org/geo",
-                                                "null",
-                                                [{"code": 200, "description": "Position Changed"}]))
+    drone.add_supported_op(HydraOp("/"+API+"/change_position",
+                                   "ChangePosition",
+                                   "PUT",
+                                   "http://schema.org/geo",
+                                   "null",
+                                   [{"code": 200, "description": "Position Changed"}]).get())
 
-    drone["supportedOperation"].append(hydra_op("/"+API+"/change_status",
-                                                "ChangeStatus",
-                                                "PUT",
-                                                "http://schema.org/status",
-                                                "null",
-                                                [{"code": 200, "description": "Status Changed"}]))
+    drone.add_supported_op(HydraOp("/"+API+"/change_status",
+                                   "ChangeStatus",
+                                   "PUT",
+                                   "http://schema.org/status",
+                                   "null",
+                                   [{"code": 200, "description": "Status Changed"}]).get())
 
-    drone["supportedOperation"].append(hydra_op("/"+API+"/get_speed",
-                                                "GetSpeed",
-                                                "GET",
-                                                "null",
-                                                "http://auto.schema.org/speed",
-                                                [{"code": 200, "description": "Speed returned"}]))
+    drone.add_supported_op(HydraOp("/"+API+"/get_speed",
+                                   "GetSpeed",
+                                   "GET",
+                                   "null",
+                                   "http://auto.schema.org/speed",
+                                   [{"code": 200, "description": "Speed returned"}]).get())
 
-    drone["supportedOperation"].append(hydra_op("/"+API+"/get_position",
-                                                "GetPosition",
-                                                "GET",
-                                                "null",
-                                                "http://schema.org/geo",
-                                                [{"code": 200, "description": "Position returned"}]))
+    drone.add_supported_op(HydraOp("/"+API+"/get_position",
+                                   "GetPosition",
+                                   "GET",
+                                   "null",
+                                   "http://schema.org/geo",
+                                   [{"code": 200, "description": "Position returned"}]).get())
 
-    drone["supportedOperation"].append(hydra_op("/"+API+"/get_battery_status",
-                                                "GetBatteryStatus",
-                                                "GET",
-                                                "null",
-                                                "http://schema.org/fuelCapacity",
-                                                [{"code": 200, "description": "Battery status returned"}]))
+    drone.add_supported_op(HydraOp("/"+API+"/get_battery_status",
+                                   "GetBatteryStatus",
+                                   "GET",
+                                   "null",
+                                   "http://schema.org/fuelCapacity",
+                                   [{"code": 200, "description": "Battery status returned"}]).get())
 
-    drone["supportedOperation"].append(hydra_op("/"+API+"/get_model",
-                                                "GetModel",
-                                                "GET",
-                                                "null",
-                                                "http://schema.org/model",
-                                                [{"code": 200, "description": "Model returned"}]))
+    drone.add_supported_op(HydraOp("/"+API+"/get_model",
+                                   "GetModel",
+                                   "GET",
+                                   "null",
+                                   "http://schema.org/model",
+                                   [{"code": 200, "description": "Model returned"}]).get())
 
-    drone["supportedOperation"].append(hydra_op("/"+API+"/get_status",
-                                                "GetStatus",
-                                                "GET",
-                                                "null",
-                                                "http://schema.org/status",
-                                                [{"code": 200, "description": "Status returned"}]))
+    drone.add_supported_op(HydraOp("/"+API+"/get_status",
+                                   "GetStatus",
+                                   "GET",
+                                   "null",
+                                   "http://schema.org/status",
+                                   [{"code": 200, "description": "Status returned"}]).get())
 
-    drone["supportedOperation"].append(hydra_op("/"+API+"/get_temperature",
-                                                "GetTemperature",
-                                                "GET",
-                                                "null",
-                                                "http://schema.org/Float",
-                                                [{"code": 200, "description": "Temperature returned"}]))
+    drone.add_supported_op(HydraOp("/"+API+"/get_temperature",
+                                   "GetTemperature",
+                                   "GET",
+                                   "null",
+                                   "http://schema.org/Float",
+                                   [{"code": 200, "description": "Temperature returned"}]).get())
 
-    drone["supportedOperation"].append(hydra_op("/"+API+"/recharge",
-                                                "GetTemperature",
-                                                "POST",
-                                                "http://schema.org/Action",
-                                                "http://schema.org/fuelCapacity",
-                                                [{"code": 200, "description": "Successfully charged"}]))
-    api_doc["supportedClass"].append(drone)
+    drone.add_supported_op(HydraOp("/"+API+"/recharge",
+                                   "GetTemperature",
+                                   "POST",
+                                   "http://schema.org/Action",
+                                   "http://schema.org/fuelCapacity",
+                                   [{"code": 200, "description": "Successfully charged"}]).get())
+    api_doc.add_supported_class(drone.get())
 
     return api_doc
 
 
 if __name__ == "__main__":
-    print(json.dumps(drone_doc("droneapi"), indent=4, sort_keys=True))
+    print(drone_doc("droneapi").to_json())

--- a/api_docs/server_doc.py
+++ b/api_docs/server_doc.py
@@ -1,0 +1,350 @@
+"""Generated API Documentation for Server API using server_doc_gen.py."""
+
+server_doc = {
+    "@context": "http://hydrus.com/contexts/serverapi.jsonld",
+    "@id": "http://hydrus.com/serverapi/vocab",
+    "@type": "ApiDocumentation",
+    "description": "API Documentation for the server side system",
+    "entrypoint": "/serverapi/",
+    "possibleStatus": [],
+    "supportedClass": [
+        {
+            "@context": "http://hydrus.com/context/Drone.jsonld",
+            "@id": "http://hydrus.com/serverapi/vocab/Drone",
+            "@type": "Class",
+            "description": "Class for a drone",
+            "supportedOperation": [
+                {
+                    "@id": "/serverapi/change_speed",
+                    "@type": "Operation",
+                    "expects": "http://auto.schema.org/speed",
+                    "method": "PUT",
+                    "possibleStatus": [
+                        {
+                            "code": 200,
+                            "description": "Speed Changed"
+                        }
+                    ],
+                    "returns": "null",
+                    "title": "ChangeSpeed"
+                },
+                {
+                    "@id": "/serverapi/change_position",
+                    "@type": "Operation",
+                    "expects": "http://schema.org/geo",
+                    "method": "PUT",
+                    "possibleStatus": [
+                        {
+                            "code": 200,
+                            "description": "Position Changed"
+                        }
+                    ],
+                    "returns": "null",
+                    "title": "ChangePosition"
+                },
+                {
+                    "@id": "/serverapi/change_status",
+                    "@type": "Operation",
+                    "expects": "http://schema.org/status",
+                    "method": "PUT",
+                    "possibleStatus": [
+                        {
+                            "code": 200,
+                            "description": "Status Changed"
+                        }
+                    ],
+                    "returns": "null",
+                    "title": "ChangeStatus"
+                },
+                {
+                    "@id": "/serverapi/get_speed",
+                    "@type": "Operation",
+                    "expects": "null",
+                    "method": "GET",
+                    "possibleStatus": [
+                        {
+                            "code": 200,
+                            "description": "Speed returned"
+                        }
+                    ],
+                    "returns": "http://auto.schema.org/speed",
+                    "title": "GetSpeed"
+                },
+                {
+                    "@id": "/serverapi/get_position",
+                    "@type": "Operation",
+                    "expects": "null",
+                    "method": "GET",
+                    "possibleStatus": [
+                        {
+                            "code": 200,
+                            "description": "Position returned"
+                        }
+                    ],
+                    "returns": "http://schema.org/geo",
+                    "title": "GetPosition"
+                },
+                {
+                    "@id": "/serverapi/get_battery_status",
+                    "@type": "Operation",
+                    "expects": "null",
+                    "method": "GET",
+                    "possibleStatus": [
+                        {
+                            "code": 200,
+                            "description": "Battery status returned"
+                        }
+                    ],
+                    "returns": "http://schema.org/fuelCapacity",
+                    "title": "GetBatteryStatus"
+                },
+                {
+                    "@id": "/serverapi/get_model",
+                    "@type": "Operation",
+                    "expects": "null",
+                    "method": "GET",
+                    "possibleStatus": [
+                        {
+                            "code": 200,
+                            "description": "Model returned"
+                        }
+                    ],
+                    "returns": "http://schema.org/model",
+                    "title": "GetModel"
+                },
+                {
+                    "@id": "/serverapi/get_status",
+                    "@type": "Operation",
+                    "expects": "null",
+                    "method": "GET",
+                    "possibleStatus": [
+                        {
+                            "code": 200,
+                            "description": "Status returned"
+                        }
+                    ],
+                    "returns": "http://schema.org/status",
+                    "title": "GetStatus"
+                },
+                {
+                    "@id": "/serverapi/get_temperature",
+                    "@type": "Operation",
+                    "expects": "null",
+                    "method": "GET",
+                    "possibleStatus": [
+                        {
+                            "code": 200,
+                            "description": "Temperature returned"
+                        }
+                    ],
+                    "returns": "http://schema.org/Float",
+                    "title": "GetTemperature"
+                },
+                {
+                    "@id": "/serverapi/recharge",
+                    "@type": "Operation",
+                    "expects": "http://schema.org/Action",
+                    "method": "POST",
+                    "possibleStatus": [
+                        {
+                            "code": 200,
+                            "description": "Successfully charged"
+                        }
+                    ],
+                    "returns": "http://schema.org/fuelCapacity",
+                    "title": "GetTemperature"
+                }
+            ],
+            "supportedProperty": [
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://auto.schema.org/speed",
+                    "readable": "true",
+                    "required": "true",
+                    "title": "Speed",
+                    "writeable": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://schema.org/geo",
+                    "readable": "true",
+                    "required": "true",
+                    "title": "Position",
+                    "writeable": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://schema.org/fuelCapacity",
+                    "readable": "true",
+                    "required": "true",
+                    "title": "Battery",
+                    "writeable": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://schema.org/device",
+                    "readable": "true",
+                    "required": "true",
+                    "title": "Sensor",
+                    "writeable": "false"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://schema.org/model",
+                    "readable": "true",
+                    "required": "true",
+                    "title": "Model",
+                    "writeable": "false"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "https://schema.org/status",
+                    "readable": "true",
+                    "required": "true",
+                    "title": "Status",
+                    "writeable": "true"
+                }
+            ],
+            "title": "Drone"
+        },
+        {
+            "@context": "http://hydrus.com/context/LogEntry.jsonld",
+            "@id": "http://hydrus.com/serverapi/vocab/LogEntry",
+            "@type": "Class",
+            "description": "Class for a log entry",
+            "supportedOperation": [
+                {
+                    "@id": "/serverapi/log_entry",
+                    "@type": "Operation",
+                    "expects": "http://hydrus.com/LogEntry",
+                    "method": "POST",
+                    "possibleStatus": [
+                        {
+                            "code": 200,
+                            "description": "Log entered"
+                        }
+                    ],
+                    "returns": "null",
+                    "title": "CreateEntry"
+                }
+            ],
+            "supportedProperty": [
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://hydrus.com/serverapi/vocab/Drone",
+                    "readable": "true",
+                    "required": "true",
+                    "title": "Drone",
+                    "writeable": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://schema.org/UpdateAction",
+                    "readable": "true",
+                    "required": "false",
+                    "title": "Update",
+                    "writeable": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://schema.org/ReplyAction",
+                    "readable": "true",
+                    "required": "false",
+                    "title": "Get",
+                    "writeable": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://auto.schema.org/speed",
+                    "readable": "true",
+                    "required": "false",
+                    "title": "Speed",
+                    "writeable": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://schema.org/geo",
+                    "readable": "true",
+                    "required": "false",
+                    "title": "Position",
+                    "writeable": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://schema.org/fuelCapacity",
+                    "readable": "true",
+                    "required": "false",
+                    "title": "Battery",
+                    "writeable": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://schema.org/device",
+                    "readable": "true",
+                    "required": "false",
+                    "title": "Sensor",
+                    "writeable": "false"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://schema.org/model",
+                    "readable": "true",
+                    "required": "false",
+                    "title": "Model",
+                    "writeable": "false"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "https://schema.org/status",
+                    "readable": "true",
+                    "required": "false",
+                    "title": "Status",
+                    "writeable": "true"
+                }
+            ],
+            "title": "LogEntry"
+        },
+        {
+            "@context": "http://hydrus.com/context/Area.jsonld",
+            "@id": "http://hydrus.com/serverapi/vocab/Area",
+            "@type": "Class",
+            "description": "Class for Area of Interest of the server",
+            "supportedOperation": [
+                {
+                    "@id": "/serverapi/update_area",
+                    "@type": "Operation",
+                    "expects": "http://hydrus.com/Area",
+                    "method": "PUT",
+                    "possibleStatus": [
+                        {
+                            "code": 200,
+                            "description": "Area of interest changed"
+                        }
+                    ],
+                    "returns": "null",
+                    "title": "UpdateArea"
+                }
+            ],
+            "supportedProperty": [
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://schema.org/geo",
+                    "readable": "true",
+                    "required": "true",
+                    "title": "TopLeft",
+                    "writeable": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://schema.org/geo",
+                    "readable": "true",
+                    "required": "true",
+                    "title": "BottomRight",
+                    "writeable": "true"
+                }
+            ],
+            "title": "Area"
+        }
+    ],
+    "title": "API Doc for the server side API"
+}

--- a/api_docs/server_doc.py
+++ b/api_docs/server_doc.py
@@ -9,44 +9,76 @@ server_doc = {
     "possibleStatus": [],
     "supportedClass": [
         {
+            "@context": "http://hydrus.com/context/Status.jsonld",
+            "@id": "http://hydrus.com/serverapi/vocab#Status",
+            "@type": "Class",
+            "description": "Class for drone status objects",
+            "subClassOf": "null",
+            "supportedOperation": [],
+            "supportedProperty": [
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://auto.schema.org/speed",
+                    "readable": "true",
+                    "required": "false",
+                    "title": "Speed",
+                    "writeable": "false"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://schema.org/geo",
+                    "readable": "true",
+                    "required": "false",
+                    "title": "Position",
+                    "writeable": "false"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://schema.org/fuelCapacity",
+                    "readable": "true",
+                    "required": "false",
+                    "title": "Battery",
+                    "writeable": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://schema.org/device",
+                    "readable": "true",
+                    "required": "false",
+                    "title": "Sensor",
+                    "writeable": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "http://schema.org/model",
+                    "readable": "true",
+                    "required": "false",
+                    "title": "Model",
+                    "writeable": "true"
+                },
+                {
+                    "@type": "SupportedProperty",
+                    "property": "https://schema.org/status",
+                    "readable": "true",
+                    "required": "false",
+                    "title": "SensorStatus",
+                    "writeable": "false"
+                }
+            ],
+            "title": "Status"
+        },
+        {
             "@context": "http://hydrus.com/context/Drone.jsonld",
-            "@id": "http://hydrus.com/serverapi/vocab/Drone",
+            "@id": "http://hydrus.com/serverapi/vocab#Drone",
             "@type": "Class",
             "description": "Class for a drone",
+            "subClassOf": "null",
             "supportedOperation": [
                 {
-                    "@id": "/serverapi/change_speed",
+                    "@id": "/serverapi/issue_order",
                     "@type": "Operation",
-                    "expects": "http://auto.schema.org/speed",
-                    "method": "PUT",
-                    "possibleStatus": [
-                        {
-                            "code": 200,
-                            "description": "Speed Changed"
-                        }
-                    ],
-                    "returns": "null",
-                    "title": "ChangeSpeed"
-                },
-                {
-                    "@id": "/serverapi/change_position",
-                    "@type": "Operation",
-                    "expects": "http://schema.org/geo",
-                    "method": "PUT",
-                    "possibleStatus": [
-                        {
-                            "code": 200,
-                            "description": "Position Changed"
-                        }
-                    ],
-                    "returns": "null",
-                    "title": "ChangePosition"
-                },
-                {
-                    "@id": "/serverapi/change_status",
-                    "@type": "Operation",
-                    "expects": "http://schema.org/status",
-                    "method": "PUT",
+                    "expects": "vocab: Status",
+                    "method": "POST",
                     "possibleStatus": [
                         {
                             "code": 200,
@@ -57,62 +89,6 @@ server_doc = {
                     "title": "ChangeStatus"
                 },
                 {
-                    "@id": "/serverapi/get_speed",
-                    "@type": "Operation",
-                    "expects": "null",
-                    "method": "GET",
-                    "possibleStatus": [
-                        {
-                            "code": 200,
-                            "description": "Speed returned"
-                        }
-                    ],
-                    "returns": "http://auto.schema.org/speed",
-                    "title": "GetSpeed"
-                },
-                {
-                    "@id": "/serverapi/get_position",
-                    "@type": "Operation",
-                    "expects": "null",
-                    "method": "GET",
-                    "possibleStatus": [
-                        {
-                            "code": 200,
-                            "description": "Position returned"
-                        }
-                    ],
-                    "returns": "http://schema.org/geo",
-                    "title": "GetPosition"
-                },
-                {
-                    "@id": "/serverapi/get_battery_status",
-                    "@type": "Operation",
-                    "expects": "null",
-                    "method": "GET",
-                    "possibleStatus": [
-                        {
-                            "code": 200,
-                            "description": "Battery status returned"
-                        }
-                    ],
-                    "returns": "http://schema.org/fuelCapacity",
-                    "title": "GetBatteryStatus"
-                },
-                {
-                    "@id": "/serverapi/get_model",
-                    "@type": "Operation",
-                    "expects": "null",
-                    "method": "GET",
-                    "possibleStatus": [
-                        {
-                            "code": 200,
-                            "description": "Model returned"
-                        }
-                    ],
-                    "returns": "http://schema.org/model",
-                    "title": "GetModel"
-                },
-                {
                     "@id": "/serverapi/get_status",
                     "@type": "Operation",
                     "expects": "null",
@@ -120,118 +96,51 @@ server_doc = {
                     "possibleStatus": [
                         {
                             "code": 200,
-                            "description": "Status returned"
+                            "description": "Status Returned"
                         }
                     ],
-                    "returns": "http://schema.org/status",
+                    "returns": "vocab: Status",
                     "title": "GetStatus"
-                },
-                {
-                    "@id": "/serverapi/get_temperature",
-                    "@type": "Operation",
-                    "expects": "null",
-                    "method": "GET",
-                    "possibleStatus": [
-                        {
-                            "code": 200,
-                            "description": "Temperature returned"
-                        }
-                    ],
-                    "returns": "http://schema.org/Float",
-                    "title": "GetTemperature"
-                },
-                {
-                    "@id": "/serverapi/recharge",
-                    "@type": "Operation",
-                    "expects": "http://schema.org/Action",
-                    "method": "POST",
-                    "possibleStatus": [
-                        {
-                            "code": 200,
-                            "description": "Successfully charged"
-                        }
-                    ],
-                    "returns": "http://schema.org/fuelCapacity",
-                    "title": "GetTemperature"
                 }
             ],
             "supportedProperty": [
                 {
                     "@type": "SupportedProperty",
-                    "property": "http://auto.schema.org/speed",
+                    "property": "vocab:Status",
                     "readable": "true",
-                    "required": "true",
-                    "title": "Speed",
-                    "writeable": "true"
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "http://schema.org/geo",
-                    "readable": "true",
-                    "required": "true",
-                    "title": "Position",
-                    "writeable": "true"
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "http://schema.org/fuelCapacity",
-                    "readable": "true",
-                    "required": "true",
-                    "title": "Battery",
-                    "writeable": "true"
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "http://schema.org/device",
-                    "readable": "true",
-                    "required": "true",
-                    "title": "Sensor",
+                    "required": "false",
+                    "title": "DroneStatus",
                     "writeable": "false"
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "http://schema.org/model",
-                    "readable": "true",
-                    "required": "true",
-                    "title": "Model",
-                    "writeable": "false"
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "https://schema.org/status",
-                    "readable": "true",
-                    "required": "true",
-                    "title": "Status",
-                    "writeable": "true"
                 }
             ],
             "title": "Drone"
         },
         {
             "@context": "http://hydrus.com/context/LogEntry.jsonld",
-            "@id": "http://hydrus.com/serverapi/vocab/LogEntry",
+            "@id": "http://hydrus.com/serverapi/vocab#LogEntry",
             "@type": "Class",
             "description": "Class for a log entry",
+            "subClassOf": "null",
             "supportedOperation": [
                 {
-                    "@id": "/serverapi/log_entry",
+                    "@id": "/serverapi/get_latest_log",
                     "@type": "Operation",
-                    "expects": "http://hydrus.com/LogEntry",
-                    "method": "POST",
+                    "expects": "vocab:LogEntry",
+                    "method": "GET",
                     "possibleStatus": [
                         {
                             "code": 200,
-                            "description": "Log entered"
+                            "description": "Log returned"
                         }
                     ],
                     "returns": "null",
-                    "title": "CreateEntry"
+                    "title": "GetLogEntries"
                 }
             ],
             "supportedProperty": [
                 {
                     "@type": "SupportedProperty",
-                    "property": "http://hydrus.com/serverapi/vocab/Drone",
+                    "property": "vocab:Drone",
                     "readable": "true",
                     "required": "true",
                     "title": "Drone",
@@ -255,49 +164,9 @@ server_doc = {
                 },
                 {
                     "@type": "SupportedProperty",
-                    "property": "http://auto.schema.org/speed",
+                    "property": "vocab:Status",
                     "readable": "true",
-                    "required": "false",
-                    "title": "Speed",
-                    "writeable": "true"
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "http://schema.org/geo",
-                    "readable": "true",
-                    "required": "false",
-                    "title": "Position",
-                    "writeable": "true"
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "http://schema.org/fuelCapacity",
-                    "readable": "true",
-                    "required": "false",
-                    "title": "Battery",
-                    "writeable": "true"
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "http://schema.org/device",
-                    "readable": "true",
-                    "required": "false",
-                    "title": "Sensor",
-                    "writeable": "false"
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "http://schema.org/model",
-                    "readable": "true",
-                    "required": "false",
-                    "title": "Model",
-                    "writeable": "false"
-                },
-                {
-                    "@type": "SupportedProperty",
-                    "property": "https://schema.org/status",
-                    "readable": "true",
-                    "required": "false",
+                    "required": "true",
                     "title": "Status",
                     "writeable": "true"
                 }
@@ -306,9 +175,10 @@ server_doc = {
         },
         {
             "@context": "http://hydrus.com/context/Area.jsonld",
-            "@id": "http://hydrus.com/serverapi/vocab/Area",
+            "@id": "http://hydrus.com/serverapi/vocab#Area",
             "@type": "Class",
             "description": "Class for Area of Interest of the server",
+            "subClassOf": "null",
             "supportedOperation": [
                 {
                     "@id": "/serverapi/update_area",

--- a/api_docs/server_doc_gen.py
+++ b/api_docs/server_doc_gen.py
@@ -1,51 +1,44 @@
 """API Doc generator for the server side API."""
 
-import json
-from doc_gen import HydraDoc, HydraClass, HydraProp, HydraOp
+from doc_writer import HydraDoc, HydraClass, HydraProp, HydraOp
 from drone_doc_gen import drone_doc
 
 
-def server_doc(API):
+def server_doc(API, BASE_URL):
     """Generate API Doc for server."""
     # Main API Doc
     api_doc = HydraDoc(API,
-                        "API Doc for the server side API",
-                        "API Documentation for the server side system",
-                        "/"+API+"/")
+                       "API Doc for the server side API",
+                       "API Documentation for the server side system",
+                       "/"+API+"/",
+                       BASE_URL)
 
     # Drone operations on server must be linked to same operations on the specific drone
-    drone = drone_doc(API).get()["supportedClass"][0]
+    drone_classes = drone_doc(API, BASE_URL).get()["supportedClass"]
 
-    log = HydraClass("LogEntry", "LogEntry", "Class for a log entry", API)
+    log = HydraClass("LogEntry", "LogEntry", "Class for a log entry", API, BASE_URL)
     # Subject
-    log.add_supported_prop(HydraProp("http://hydrus.com/serverapi/vocab/Drone", "Drone", "true", "true", "true").get())
-
+    log.add_supported_prop(HydraProp("vocab:Drone", "Drone", "true", "true", "true").get())
     # Predicate
     log.add_supported_prop(HydraProp("http://schema.org/UpdateAction", "Update", "true", "true", "false").get())
     log.add_supported_prop(HydraProp("http://schema.org/ReplyAction", "Get", "true", "true", "false").get())
-
     # Objects
-    log.add_supported_prop(HydraProp("http://auto.schema.org/speed", "Speed", "true", "true", "false").get())
-    log.add_supported_prop(HydraProp("http://schema.org/geo", "Position", "true", "true", "false").get())
-    log.add_supported_prop(HydraProp("http://schema.org/fuelCapacity", "Battery", "true", "true", "false").get())
-    log.add_supported_prop(HydraProp("http://schema.org/device", "Sensor", "true", "false", "false").get())
-    log.add_supported_prop(HydraProp("http://schema.org/model", "Model", "true", "false", "false").get())
-    log.add_supported_prop(HydraProp("https://schema.org/status", "Status", "true", "true", "false").get())
-
+    log.add_supported_prop(HydraProp("vocab:Status", "Status", "true", "true", "true").get())
     # Only create operation for logs
-    log.add_supported_op(HydraOp("/"+API+"/log_entry",
-                                 "CreateEntry",
-                                 "POST",
-                                 "http://hydrus.com/LogEntry",
+    log.add_supported_op(HydraOp("/"+API+"/get_latest_log",
+                                 "GetLogEntries",
+                                 "GET",
+                                 "vocab:LogEntry",
                                  "null",
-                                 [{"code": 200, "description": "Log entered"}]).get())
+                                 [{"code": 200, "description": "Log returned"}]).get())
 
-    area = HydraClass("Area", "Area", "Class for Area of Interest of the server", API)
+    data = HydraClass("Data", "Data", "Class for a data entry", API, BASE_URL)
+    data.add_supported_prop(HydraProp("http://schema.org/QuantitativeValue", "Temperature", "true", "true", "false").get())
 
+    area = HydraClass("Area", "Area", "Class for Area of Interest of the server", API, BASE_URL)
     # Using two positions to have a bounding box
     area.add_supported_prop(HydraProp("http://schema.org/geo", "TopLeft", "true", "true", "true").get())
     area.add_supported_prop(HydraProp("http://schema.org/geo", "BottomRight", "true", "true", "true").get())
-
     # Allowing updation of the area of interest
     area.add_supported_op(HydraOp("/"+API+"/update_area",
                                   "UpdateArea",
@@ -54,11 +47,13 @@ def server_doc(API):
                                   "null",
                                   [{"code": 200, "description": "Area of interest changed"}]).get())
 
-    api_doc.add_supported_class(drone)
+    for class_ in drone_classes:
+        api_doc.add_supported_class(class_)
     api_doc.add_supported_class(log.get())
     api_doc.add_supported_class(area.get())
+
     return api_doc
 
 
 if __name__ == "__main__":
-    print(server_doc("serverapi").to_json())
+    print(server_doc("serverapi", "http://hydrus.com/").to_json())

--- a/api_docs/server_doc_gen.py
+++ b/api_docs/server_doc_gen.py
@@ -1,64 +1,64 @@
 """API Doc generator for the server side API."""
 
 import json
-from doc_gen import hydra_doc, hydra_class, hydra_prop, hydra_op
+from doc_gen import HydraDoc, HydraClass, HydraProp, HydraOp
 from drone_doc_gen import drone_doc
 
 
 def server_doc(API):
     """Generate API Doc for server."""
     # Main API Doc
-    api_doc = hydra_doc(API,
+    api_doc = HydraDoc(API,
                         "API Doc for the server side API",
                         "API Documentation for the server side system",
                         "/"+API+"/")
 
     # Drone operations on server must be linked to same operations on the specific drone
-    drone = drone_doc(API)["supportedClass"][0]
+    drone = drone_doc(API).get()["supportedClass"][0]
 
-    log = hydra_class("LogEntry", "LogEntry", "Class for a log entry", API)
+    log = HydraClass("LogEntry", "LogEntry", "Class for a log entry", API)
     # Subject
-    log["supportedProperty"].append(hydra_prop("http://hydrus.com/serverapi/vocab/Drone", "Drone", "true", "true", "true"))
+    log.add_supported_prop(HydraProp("http://hydrus.com/serverapi/vocab/Drone", "Drone", "true", "true", "true").get())
 
     # Predicate
-    log["supportedProperty"].append(hydra_prop("http://schema.org/UpdateAction", "Update", "true", "true", "false"))
-    log["supportedProperty"].append(hydra_prop("http://schema.org/ReplyAction", "Get", "true", "true", "false"))
+    log.add_supported_prop(HydraProp("http://schema.org/UpdateAction", "Update", "true", "true", "false").get())
+    log.add_supported_prop(HydraProp("http://schema.org/ReplyAction", "Get", "true", "true", "false").get())
 
     # Objects
-    log["supportedProperty"].append(hydra_prop("http://auto.schema.org/speed", "Speed", "true", "true", "false"))
-    log["supportedProperty"].append(hydra_prop("http://schema.org/geo", "Position", "true", "true", "false"))
-    log["supportedProperty"].append(hydra_prop("http://schema.org/fuelCapacity", "Battery", "true", "true", "false"))
-    log["supportedProperty"].append(hydra_prop("http://schema.org/device", "Sensor", "true", "false", "false"))
-    log["supportedProperty"].append(hydra_prop("http://schema.org/model", "Model", "true", "false", "false"))
-    log["supportedProperty"].append(hydra_prop("https://schema.org/status", "Status", "true", "true", "false"))
+    log.add_supported_prop(HydraProp("http://auto.schema.org/speed", "Speed", "true", "true", "false").get())
+    log.add_supported_prop(HydraProp("http://schema.org/geo", "Position", "true", "true", "false").get())
+    log.add_supported_prop(HydraProp("http://schema.org/fuelCapacity", "Battery", "true", "true", "false").get())
+    log.add_supported_prop(HydraProp("http://schema.org/device", "Sensor", "true", "false", "false").get())
+    log.add_supported_prop(HydraProp("http://schema.org/model", "Model", "true", "false", "false").get())
+    log.add_supported_prop(HydraProp("https://schema.org/status", "Status", "true", "true", "false").get())
 
     # Only create operation for logs
-    log["supportedOperation"].append(hydra_op("/"+API+"/log_entry",
-                                              "CreateEntry",
-                                              "POST",
-                                              "http://hydrus.com/LogEntry",
-                                              "null",
-                                              [{"code": 200, "description": "Log entered"}]))
+    log.add_supported_op(HydraOp("/"+API+"/log_entry",
+                                 "CreateEntry",
+                                 "POST",
+                                 "http://hydrus.com/LogEntry",
+                                 "null",
+                                 [{"code": 200, "description": "Log entered"}]).get())
 
-    area = hydra_class("Area", "Area", "Class for Area of Interest of the server", API)
+    area = HydraClass("Area", "Area", "Class for Area of Interest of the server", API)
 
     # Using two positions to have a bounding box
-    area["supportedProperty"].append(hydra_prop("http://schema.org/geo", "TopLeft", "true", "true", "true"))
-    area["supportedProperty"].append(hydra_prop("http://schema.org/geo", "BottomRight", "true", "true", "true"))
+    area.add_supported_prop(HydraProp("http://schema.org/geo", "TopLeft", "true", "true", "true").get())
+    area.add_supported_prop(HydraProp("http://schema.org/geo", "BottomRight", "true", "true", "true").get())
 
     # Allowing updation of the area of interest
-    area["supportedOperation"].append(hydra_op("/"+API+"/update_area",
-                                               "UpdateArea",
-                                               "PUT",
-                                               "http://hydrus.com/Area",
-                                               "null",
-                                               [{"code": 200, "description": "Area of interest changed"}]))
+    area.add_supported_op(HydraOp("/"+API+"/update_area",
+                                  "UpdateArea",
+                                  "PUT",
+                                  "http://hydrus.com/Area",
+                                  "null",
+                                  [{"code": 200, "description": "Area of interest changed"}]).get())
 
-    api_doc["supportedClass"].append(drone)
-    api_doc["supportedClass"].append(log)
-    api_doc["supportedClass"].append(area)
+    api_doc.add_supported_class(drone)
+    api_doc.add_supported_class(log.get())
+    api_doc.add_supported_class(area.get())
     return api_doc
 
 
 if __name__ == "__main__":
-    print(json.dumps(server_doc("serverapi"), indent=4, sort_keys=True))
+    print(server_doc("serverapi").to_json())

--- a/api_docs/server_doc_gen.py
+++ b/api_docs/server_doc_gen.py
@@ -1,0 +1,64 @@
+"""API Doc generator for the server side API."""
+
+import json
+from doc_gen import hydra_doc, hydra_class, hydra_prop, hydra_op
+from drone_doc_gen import drone_doc
+
+
+def server_doc(API):
+    """Generate API Doc for server."""
+    # Main API Doc
+    api_doc = hydra_doc(API,
+                        "API Doc for the server side API",
+                        "API Documentation for the server side system",
+                        "/"+API+"/")
+
+    # Drone operations on server must be linked to same operations on the specific drone
+    drone = drone_doc(API)["supportedClass"][0]
+
+    log = hydra_class("LogEntry", "LogEntry", "Class for a log entry", API)
+    # Subject
+    log["supportedProperty"].append(hydra_prop("http://hydrus.com/serverapi/vocab/Drone", "Drone", "true", "true", "true"))
+
+    # Predicate
+    log["supportedProperty"].append(hydra_prop("http://schema.org/UpdateAction", "Update", "true", "true", "false"))
+    log["supportedProperty"].append(hydra_prop("http://schema.org/ReplyAction", "Get", "true", "true", "false"))
+
+    # Objects
+    log["supportedProperty"].append(hydra_prop("http://auto.schema.org/speed", "Speed", "true", "true", "false"))
+    log["supportedProperty"].append(hydra_prop("http://schema.org/geo", "Position", "true", "true", "false"))
+    log["supportedProperty"].append(hydra_prop("http://schema.org/fuelCapacity", "Battery", "true", "true", "false"))
+    log["supportedProperty"].append(hydra_prop("http://schema.org/device", "Sensor", "true", "false", "false"))
+    log["supportedProperty"].append(hydra_prop("http://schema.org/model", "Model", "true", "false", "false"))
+    log["supportedProperty"].append(hydra_prop("https://schema.org/status", "Status", "true", "true", "false"))
+
+    # Only create operation for logs
+    log["supportedOperation"].append(hydra_op("/"+API+"/log_entry",
+                                              "CreateEntry",
+                                              "POST",
+                                              "http://hydrus.com/LogEntry",
+                                              "null",
+                                              [{"code": 200, "description": "Log entered"}]))
+
+    area = hydra_class("Area", "Area", "Class for Area of Interest of the server", API)
+
+    # Using two positions to have a bounding box
+    area["supportedProperty"].append(hydra_prop("http://schema.org/geo", "TopLeft", "true", "true", "true"))
+    area["supportedProperty"].append(hydra_prop("http://schema.org/geo", "BottomRight", "true", "true", "true"))
+
+    # Allowing updation of the area of interest
+    area["supportedOperation"].append(hydra_op("/"+API+"/update_area",
+                                               "UpdateArea",
+                                               "PUT",
+                                               "http://hydrus.com/Area",
+                                               "null",
+                                               [{"code": 200, "description": "Area of interest changed"}]))
+
+    api_doc["supportedClass"].append(drone)
+    api_doc["supportedClass"].append(log)
+    api_doc["supportedClass"].append(area)
+    return api_doc
+
+
+if __name__ == "__main__":
+    print(json.dumps(server_doc("serverapi"), indent=4, sort_keys=True))

--- a/class_creator.py
+++ b/class_creator.py
@@ -1,0 +1,54 @@
+"""Generate classes from parsed_classes with proper getter and setter for each Property."""
+
+from api_docs.server_doc import server_doc
+from api_docs.drone_doc import drone_doc
+import pdb
+
+
+def create_setter(prop):
+    """Create a setter for a given Property."""
+    template = """def set_%s(self, value):
+    self.%s = value""" % (prop["title"], prop["title"])
+    name = "set_%s" % prop["title"]
+    exec(template)
+    return eval(name), name
+
+
+def create_getter(prop):
+    """Create a setter for a given Property."""
+    template = """def get_%s(self):
+    return self.%s""" % (prop["title"], prop["title"])
+    name = "get_%s" % prop["title"]
+    exec(template)
+    return eval(name), name
+
+
+def create_class(class_):
+    """Create a class using a Hydra Class."""
+    class_name = class_["title"]
+    Class_ = type(class_name, (), {})
+
+    # Adding setters and getters for class properties
+    for prop in class_["supportedProperty"]:
+        getfn, getname = create_getter(prop)
+        setfn, setname = create_setter(prop)
+        setattr(Class_, getname, getfn)
+        setattr(Class_, setname, setfn)
+
+    return Class_
+
+
+def create_classes(classes):
+    """Create a classes using parsed_classes."""
+    class_dict = dict()
+    for class_ in classes:
+        class_dict[class_["title"]] = create_class(class_)
+    return class_dict
+
+
+if __name__ == "__main__":
+    server_parsed_classes = server_doc["supportedClass"]
+    drone_parsed_classes = drone_doc["supportedClass"]
+
+    class_ = create_classes(drone_parsed_classes)
+    pdb.set_trace()

--- a/class_creator.py
+++ b/class_creator.py
@@ -2,7 +2,6 @@
 
 from api_docs.server_doc import server_doc
 from api_docs.drone_doc import drone_doc
-import pdb
 
 
 def create_setter(prop):
@@ -51,4 +50,3 @@ if __name__ == "__main__":
     drone_parsed_classes = drone_doc["supportedClass"]
 
     class_ = create_classes(drone_parsed_classes)
-    pdb.set_trace()


### PR DESCRIPTION
Added API Documentation for Server and Drone APIs.

Created generator functions for creating the API Doc, it should be easy to modify and generate the docs for both Server and Drone.

The Server has a copy of the Drone Class, having same properties and operations. It would be better if these are mapped to the properties and operations on the Drone API.
Server also has LogEntry for all the log entries and Area for the area of interest.

Please review
